### PR TITLE
Fix typos in docstrings

### DIFF
--- a/src/adtk/_aggregator_base.py
+++ b/src/adtk/_aggregator_base.py
@@ -34,7 +34,7 @@ class _Aggregator(_Model):
         return self._predict_core(lists)
 
     def aggregate(self, lists):
-        """Aggregate mulitple lists of anomalies into one.
+        """Aggregate multiple lists of anomalies into one.
 
         Parameters
         ----------

--- a/src/adtk/aggregator/aggregator.py
+++ b/src/adtk/aggregator/aggregator.py
@@ -18,7 +18,7 @@ class CustomizedAggregator(_Aggregator):
     Parameters
     ----------
     aggregate_func: function
-        A function aggregating mulitple lists of anomalies. The first input
+        A function aggregating multiple lists of anomalies. The first input
         argument must be a dict, optional input argument allows (through
         parameter `aggregate_func_params`). The output must be a list of pandas
         Timestamps.


### PR DESCRIPTION
Hi! I saw these while I browsing the source code. I didn't open an issue since it is a simple typo fix in docstrings.