### PR TITLE
Optimize pipenet API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     scikit-learn>=0.20
     statsmodels>=0.9
     packaging>=17.0
+    tabulate>=0.8
 
 [options.packages.find]
 where = src

--- a/src/adtk/detector/detector_1d.py
+++ b/src/adtk/detector/detector_1d.py
@@ -471,9 +471,8 @@ class PersistAD(_Detector1D):
         agg=_default_params["agg"],
     ):
         self.pipe_ = Pipenet(
-            [
-                {
-                    "name": "diff_abs",
+            {
+                "diff_abs": {
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=(window, 1),
@@ -483,13 +482,11 @@ class PersistAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": InterQuartileRangeAD(c=(None, c)),
                     "input": "diff_abs",
                 },
-                {
-                    "name": "diff",
+                "diff": {
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=(window, 1),
@@ -499,8 +496,7 @@ class PersistAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": ThresholdAD(
                         high=(
                             0.0
@@ -523,12 +519,11 @@ class PersistAD(_Detector1D):
                     ),
                     "input": "diff",
                 },
-                {
-                    "name": "and",
+                "and": {
                     "model": AndAggregator(),
                     "input": ["iqr_ad", "sign_check"],
                 },
-            ]
+            }
         )
         super().__init__(
             c=c, side=side, window=window, min_periods=min_periods, agg=agg
@@ -544,19 +539,22 @@ class PersistAD(_Detector1D):
             raise ValueError(
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
-        self.pipe_.steps[0]["model"].agg = self.agg
-        self.pipe_.steps[0]["model"].window = (self.window, 1)
-        self.pipe_.steps[0]["model"].min_periods = (self.min_periods, 1)
-        self.pipe_.steps[1]["model"].c = (None, self.c)
-        self.pipe_.steps[2]["model"].agg = self.agg
-        self.pipe_.steps[2]["model"].window = (self.window, 1)
-        self.pipe_.steps[2]["model"].min_periods = (self.min_periods, 1)
-        self.pipe_.steps[3]["model"].high = (
+        self.pipe_.steps["diff_abs"]["model"].agg = self.agg
+        self.pipe_.steps["diff_abs"]["model"].window = (self.window, 1)
+        self.pipe_.steps["diff_abs"]["model"].min_periods = (
+            self.min_periods,
+            1,
+        )
+        self.pipe_.steps["iqr_ad"]["model"].c = (None, self.c)
+        self.pipe_.steps["diff"]["model"].agg = self.agg
+        self.pipe_.steps["diff"]["model"].window = (self.window, 1)
+        self.pipe_.steps["diff"]["model"].min_periods = (self.min_periods, 1)
+        self.pipe_.steps["sign_check"]["model"].high = (
             0.0
             if self.side == "positive"
             else (float("inf") if self.side == "negative" else -float("inf"))
         )
-        self.pipe_.steps[3]["model"].low = (
+        self.pipe_.steps["sign_check"]["model"].low = (
             0.0
             if self.side == "negative"
             else (-float("inf") if self.side == "positive" else float("inf"))
@@ -630,9 +628,8 @@ class LevelShiftAD(_Detector1D):
         min_periods=_default_params["min_periods"],
     ):
         self.pipe_ = Pipenet(
-            [
-                {
-                    "name": "diff_abs",
+            {
+                "diff_abs": {
                     "model": DoubleRollingAggregate(
                         agg="median",
                         window=window,
@@ -642,13 +639,11 @@ class LevelShiftAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": InterQuartileRangeAD((None, c)),
                     "input": "diff_abs",
                 },
-                {
-                    "name": "diff",
+                "diff": {
                     "model": DoubleRollingAggregate(
                         agg="median",
                         window=window,
@@ -658,8 +653,7 @@ class LevelShiftAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": ThresholdAD(
                         high=(
                             0.0
@@ -682,12 +676,11 @@ class LevelShiftAD(_Detector1D):
                     ),
                     "input": "diff",
                 },
-                {
-                    "name": "and",
+                "and": {
                     "model": AndAggregator(),
                     "input": ["iqr_ad", "sign_check"],
                 },
-            ]
+            }
         )
         super().__init__(
             c=c, side=side, window=window, min_periods=min_periods
@@ -699,17 +692,17 @@ class LevelShiftAD(_Detector1D):
             raise ValueError(
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
-        self.pipe_.steps[0]["model"].window = self.window
-        self.pipe_.steps[0]["model"].min_periods = self.min_periods
-        self.pipe_.steps[1]["model"].c = (None, self.c)
-        self.pipe_.steps[2]["model"].window = self.window
-        self.pipe_.steps[2]["model"].min_periods = self.min_periods
-        self.pipe_.steps[3]["model"].high = (
+        self.pipe_.steps["diff_abs"]["model"].window = self.window
+        self.pipe_.steps["diff_abs"]["model"].min_periods = self.min_periods
+        self.pipe_.steps["iqr_ad"]["model"].c = (None, self.c)
+        self.pipe_.steps["diff"]["model"].window = self.window
+        self.pipe_.steps["diff"]["model"].min_periods = self.min_periods
+        self.pipe_.steps["sign_check"]["model"].high = (
             0.0
             if self.side == "positive"
             else (float("inf") if self.side == "negative" else -float("inf"))
         )
-        self.pipe_.steps[3]["model"].low = (
+        self.pipe_.steps["sign_check"]["model"].low = (
             0.0
             if self.side == "negative"
             else (-float("inf") if self.side == "positive" else float("inf"))
@@ -790,9 +783,8 @@ class VolatilityShiftAD(_Detector1D):
         agg=_default_params["agg"],
     ):
         self.pipe_ = Pipenet(
-            [
-                {
-                    "name": "diff_abs",
+            {
+                "diff_abs": {
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=window,
@@ -802,13 +794,11 @@ class VolatilityShiftAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": InterQuartileRangeAD((None, c)),
                     "input": "diff_abs",
                 },
-                {
-                    "name": "diff",
+                "diff": {
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=window,
@@ -818,8 +808,7 @@ class VolatilityShiftAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": ThresholdAD(
                         high=(
                             0.0
@@ -842,12 +831,11 @@ class VolatilityShiftAD(_Detector1D):
                     ),
                     "input": "diff",
                 },
-                {
-                    "name": "and",
+                "and": {
                     "model": AndAggregator(),
                     "input": ["iqr_ad", "sign_check"],
                 },
-            ]
+            }
         )
         super().__init__(
             agg=agg, c=c, side=side, window=window, min_periods=min_periods
@@ -861,19 +849,19 @@ class VolatilityShiftAD(_Detector1D):
             raise ValueError(
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
-        self.pipe_.steps[0]["model"].agg = self.agg
-        self.pipe_.steps[0]["model"].window = self.window
-        self.pipe_.steps[0]["model"].min_periods = self.min_periods
-        self.pipe_.steps[1]["model"].c = (None, self.c)
-        self.pipe_.steps[2]["model"].agg = self.agg
-        self.pipe_.steps[2]["model"].window = self.window
-        self.pipe_.steps[2]["model"].min_periods = self.min_periods
-        self.pipe_.steps[3]["model"].high = (
+        self.pipe_.steps["diff_abs"]["model"].agg = self.agg
+        self.pipe_.steps["diff_abs"]["model"].window = self.window
+        self.pipe_.steps["diff_abs"]["model"].min_periods = self.min_periods
+        self.pipe_.steps["iqr_ad"]["model"].c = (None, self.c)
+        self.pipe_.steps["diff"]["model"].agg = self.agg
+        self.pipe_.steps["diff"]["model"].window = self.window
+        self.pipe_.steps["diff"]["model"].min_periods = self.min_periods
+        self.pipe_.steps["sign_check"]["model"].high = (
             0.0
             if self.side == "positive"
             else (float("inf") if self.side == "negative" else -float("inf"))
         )
-        self.pipe_.steps[3]["model"].low = (
+        self.pipe_.steps["sign_check"]["model"].low = (
             0.0
             if self.side == "negative"
             else (-float("inf") if self.side == "positive" else float("inf"))
@@ -962,31 +950,26 @@ class AutoregressionAD(_Detector1D):
         if regressor is None:
             regressor = LinearRegression()
         self.pipe_ = Pipenet(
-            [
-                {
-                    "name": "retrospetive",
+            {
+                "retrospetive": {
                     "model": Retrospect(
                         n_steps=n_steps + 1, step_size=step_size
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "regression_residual",
+                "regression_residual": {
                     "model": RegressionResidual(regressor=regressor),
                     "input": "retrospetive",
                 },
-                {
-                    "name": "abs_residual",
+                "abs_residual": {
                     "model": CustomizedTransformer1D(transform_func=abs),
                     "input": "regression_residual",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": InterQuartileRangeAD((None, c)),
                     "input": "abs_residual",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": ThresholdAD(
                         high=(
                             0.0
@@ -1009,12 +992,11 @@ class AutoregressionAD(_Detector1D):
                     ),
                     "input": "regression_residual",
                 },
-                {
-                    "name": "and",
+                "and": {
                     "model": AndAggregator(),
                     "input": ["iqr_ad", "sign_check"],
                 },
-            ]
+            }
         )
         super().__init__(
             n_steps=n_steps,
@@ -1030,16 +1012,18 @@ class AutoregressionAD(_Detector1D):
             raise ValueError(
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
-        self.pipe_.steps[0]["model"].n_steps = self.n_steps + 1
-        self.pipe_.steps[0]["model"].step_size = self.step_size
-        self.pipe_.steps[1]["model"].regressor = self.regressor
-        self.pipe_.steps[3]["model"].c = (None, self.c)
-        self.pipe_.steps[4]["model"].high = (
+        self.pipe_.steps["retrospetive"]["model"].n_steps = self.n_steps + 1
+        self.pipe_.steps["retrospetive"]["model"].step_size = self.step_size
+        self.pipe_.steps["regression_residual"][
+            "model"
+        ].regressor = self.regressor
+        self.pipe_.steps["iqr_ad"]["model"].c = (None, self.c)
+        self.pipe_.steps["sign_check"]["model"].high = (
             0.0
             if self.side == "positive"
             else (float("inf") if self.side == "negative" else -float("inf"))
         )
-        self.pipe_.steps[4]["model"].low = (
+        self.pipe_.steps["sign_check"]["model"].low = (
             0.0
             if self.side == "negative"
             else (-float("inf") if self.side == "positive" else float("inf"))
@@ -1126,9 +1110,8 @@ class SeasonalAD(_Detector1D):
         c=_default_params["c"],
     ):
         self.pipe_ = Pipenet(
-            [
-                {
-                    "name": "deseasonal_residual",
+            {
+                "deseasonal_residual": {
                     "model": (
                         NaiveSeasonalDecomposition(freq=freq)
                         if method == "naive"
@@ -1136,18 +1119,15 @@ class SeasonalAD(_Detector1D):
                     ),
                     "input": "original",
                 },
-                {
-                    "name": "abs_residual",
+                "abs_residual": {
                     "model": CustomizedTransformer1D(transform_func=abs),
                     "input": "deseasonal_residual",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": InterQuartileRangeAD((None, c)),
                     "input": "abs_residual",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": ThresholdAD(
                         high=(
                             0.0
@@ -1170,12 +1150,11 @@ class SeasonalAD(_Detector1D):
                     ),
                     "input": "deseasonal_residual",
                 },
-                {
-                    "name": "and",
+                "and": {
                     "model": AndAggregator(),
                     "input": ["iqr_ad", "sign_check"],
                 },
-            ]
+            }
         )
         super().__init__(method=method, freq=freq, side=side, c=c)
         self._sync_params()
@@ -1184,22 +1163,27 @@ class SeasonalAD(_Detector1D):
         if self.method not in ["naive", "stl"]:
             raise ValueError("Parameter `method` must be 'naive' or 'stl'.")
         if (self.method == "naive") and (
-            self.pipe_.steps[0]["model"].__class__
+            self.pipe_.steps["deseasonal_residual"]["model"].__class__
             != NaiveSeasonalDecomposition
         ):
-            self.pipe_.steps[0]["model"] = NaiveSeasonalDecomposition()
+            self.pipe_.steps["deseasonal_residual"][
+                "model"
+            ] = NaiveSeasonalDecomposition()
         if (self.method == "stl") and (
-            self.pipe_.steps[0]["model"].__class__ != STLDecomposition
+            self.pipe_.steps["deseasonal_residual"]["model"].__class__
+            != STLDecomposition
         ):
-            self.pipe_.steps[0]["model"] = STLDecomposition()
-        self.pipe_.steps[0]["model"].freq = self.freq
-        self.pipe_.steps[2]["model"].c = (None, self.c)
-        self.pipe_.steps[3]["model"].high = (
+            self.pipe_.steps["deseasonal_residual"][
+                "model"
+            ] = STLDecomposition()
+        self.pipe_.steps["deseasonal_residual"]["model"].freq = self.freq
+        self.pipe_.steps["iqr_ad"]["model"].c = (None, self.c)
+        self.pipe_.steps["sign_check"]["model"].high = (
             0.0
             if self.side == "positive"
             else (float("inf") if self.side == "negative" else -float("inf"))
         )
-        self.pipe_.steps[3]["model"].low = (
+        self.pipe_.steps["sign_check"]["model"].low = (
             0.0
             if self.side == "negative"
             else (-float("inf") if self.side == "positive" else float("inf"))
@@ -1208,8 +1192,10 @@ class SeasonalAD(_Detector1D):
     def _fit_core(self, s):
         self._sync_params()
         self.pipe_.fit(s)
-        self.freq_ = self.pipe_.steps[0]["model"].freq_
-        self.seasonal_ = self.pipe_.steps[0]["model"].seasonal_
+        self.freq_ = self.pipe_.steps["deseasonal_residual"]["model"].freq_
+        self.seasonal_ = self.pipe_.steps["deseasonal_residual"][
+            "model"
+        ].seasonal_
 
     def _predict_core(self, s):
         self._sync_params()

--- a/src/adtk/pipe/pipe.py
+++ b/src/adtk/pipe/pipe.py
@@ -54,7 +54,7 @@ class Pipeline:
         pipenet_steps = dict()
         last_name = "original"
         for pipeline_step in self.steps:
-            pipenet_step.update(
+            pipenet_steps.update(
                 {
                     pipeline_step[0]: {
                         "model": pipeline_step[1],

--- a/src/adtk/pipe/pipe.py
+++ b/src/adtk/pipe/pipe.py
@@ -1045,10 +1045,8 @@ class Pipenet:
 
     def summary(self):
         """Print a summary of the pipenet."""
-        df = pd.DataFrame(
-            columns=["name", "model", "input", "subset", "order"]
-        )
-        for step_name, exe_order in self.steps_graph_.items():
+        df = pd.DataFrame(columns=["name", "model", "input", "subset"])
+        for step_name in self.steps_graph_.keys():
             if step_name == "original":
                 continue
             df = df.append(
@@ -1061,7 +1059,6 @@ class Pipenet:
                         if hasattr(self.steps[step_name], "subset")
                         else "all"
                     ),
-                    "order": exe_order,
                 },
                 ignore_index=True,
             )

--- a/src/adtk/pipe/pipe.py
+++ b/src/adtk/pipe/pipe.py
@@ -13,6 +13,8 @@ from matplotlib.collections import PatchCollection
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle
 
+from tabulate import tabulate
+
 from .._base import _Model
 from .._detector_base import _Detector1D, _DetectorHD
 from .._transformer_base import _Transformer1D, _TransformerHD
@@ -1040,6 +1042,30 @@ class Pipenet:
             step_name: step["model"].get_params()
             for step_name, step in self.steps.items()
         }
+
+    def summary(self):
+        """Print a summary of the pipenet."""
+        df = pd.DataFrame(
+            columns=["name", "model", "input", "subset", "order"]
+        )
+        for step_name, exe_order in self.steps_graph_.items():
+            if step_name == "original":
+                continue
+            df = df.append(
+                {
+                    "name": step_name,
+                    "model": self.steps[step_name]["model"].__class__.__name__,
+                    "input": self.steps[step_name]["input"],
+                    "subset": (
+                        self.steps[step_name]["subset"]
+                        if hasattr(self.steps[step_name], "subset")
+                        else "all"
+                    ),
+                    "order": exe_order,
+                },
+                ignore_index=True,
+            )
+        print(tabulate(df, headers="keys", tablefmt="simple", showindex=False))
 
     def plot_flowchart(self, ax=None, figsize=None, radius=1.0):
         """Plot flowchart of this pipenet.

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -16,35 +16,30 @@ def test_detector_return_intermediate():
         index=pd.date_range(start="2017-1-1", periods=60, freq="D"),
     )
     my_pipe = Pipenet(
-        [
-            {
-                "name": "deseasonal_residual",
+        {
+            "deseasonal_residual": {
                 "model": (transformer.NaiveSeasonalDecomposition(freq=6)),
                 "input": "original",
             },
-            {
-                "name": "abs_residual",
+            "abs_residual": {
                 "model": transformer.CustomizedTransformer1D(
                     transform_func=abs
                 ),
                 "input": "deseasonal_residual",
             },
-            {
-                "name": "iqr_ad",
+            "iqr_ad": {
                 "model": detector.InterQuartileRangeAD(c=(None, 3)),
                 "input": "abs_residual",
             },
-            {
-                "name": "sign_check",
+            "sign_check": {
                 "model": detector.ThresholdAD(high=0.0, low=-float("inf")),
                 "input": "deseasonal_residual",
             },
-            {
-                "name": "and",
+            "and": {
                 "model": aggregator.AndAggregator(),
                 "input": ["iqr_ad", "sign_check"],
             },
-        ]
+        }
     )
     result = my_pipe.fit_detect(s, return_intermediate=True)
     assert set(result.keys()) == {
@@ -66,35 +61,30 @@ def test_skip_fit():
     deseasonal_residual = transformer.NaiveSeasonalDecomposition(freq=6)
 
     my_pipe = Pipenet(
-        [
-            {
-                "name": "deseasonal_residual",
+        {
+            "deseasonal_residual": {
                 "model": deseasonal_residual,
                 "input": "original",
             },
-            {
-                "name": "abs_residual",
+            "abs_residual": {
                 "model": transformer.CustomizedTransformer1D(
                     transform_func=abs
                 ),
                 "input": "deseasonal_residual",
             },
-            {
-                "name": "iqr_ad",
+            "iqr_ad": {
                 "model": detector.InterQuartileRangeAD(c=(None, 3)),
                 "input": "abs_residual",
             },
-            {
-                "name": "sign_check",
+            "sign_check": {
                 "model": detector.ThresholdAD(high=0.0, low=-float("inf")),
                 "input": "deseasonal_residual",
             },
-            {
-                "name": "and",
+            "and": {
                 "model": aggregator.AndAggregator(),
                 "input": ["iqr_ad", "sign_check"],
             },
-        ]
+        }
     )
     with pytest.raises(RuntimeError):
         my_pipe.fit_detect(s, skip_fit=["deseasonal_residual"])
@@ -104,30 +94,26 @@ def test_skip_fit():
 def test_nonunique_output():
     with pytest.raises(ValueError, match="ambiguous"):
         Pipenet(
-            [
-                {
-                    "name": "deseasonal_residual",
+            {
+                "deseasonal_residual": {
                     "model": (transformer.NaiveSeasonalDecomposition(freq=6)),
                     "input": "original",
                 },
-                {
-                    "name": "abs_residual",
+                "abs_residual": {
                     "model": transformer.CustomizedTransformer1D(
                         transform_func=abs
                     ),
                     "input": "deseasonal_residual",
                 },
-                {
-                    "name": "iqr_ad",
+                "iqr_ad": {
                     "model": detector.InterQuartileRangeAD(c=(None, 3)),
                     "input": "abs_residual",
                 },
-                {
-                    "name": "sign_check",
+                "sign_check": {
                     "model": detector.ThresholdAD(high=0.0, low=-float("inf")),
                     "input": "deseasonal_residual",
                 },
-            ]
+            }
         )
 
 
@@ -137,20 +123,18 @@ def test_transformer_pipe():
         index=pd.date_range(start="2017-1-1", periods=60, freq="D"),
     )
     my_pipe = Pipenet(
-        [
-            {
-                "name": "deseasonal_residual",
+        {
+            "deseasonal_residual": {
                 "model": transformer.NaiveSeasonalDecomposition(freq=6),
                 "input": "original",
             },
-            {
-                "name": "abs_residual",
+            "abs_residual": {
                 "model": transformer.CustomizedTransformer1D(
                     transform_func=abs
                 ),
                 "input": "deseasonal_residual",
             },
-        ]
+        }
     )
     with pytest.raises(RuntimeError, match="`fit_transform`"):
         my_pipe.fit_detect(s)


### PR DESCRIPTION
This PR resolves issues #16 and #15 

- [x] We changed the type of the pipenet parameter `steps` from a list of dict objects to a dict where keys are step names and values are step config. This follows the discussion in #16.
- [x] We added a `summary` method to pipenet to pretty-print key configures of the object.
- [x] We updated the example notebook in the documentation accordingly (see cell 56 - 59). 