### PR TITLE
Move univariate notes to top of docstrings

### DIFF
--- a/src/adtk/detector/detector_1d.py
+++ b/src/adtk/detector/detector_1d.py
@@ -40,6 +40,13 @@ __all__ = [
 class CustomizedDetector1D(_Detector1D):
     """Detector derived from a user-given function and parameters.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     detect_func: function
@@ -56,14 +63,6 @@ class CustomizedDetector1D(_Detector1D):
 
     fit_func_params: dict, optional
         Parameters of fit_func. Default: None.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -135,6 +134,13 @@ class ThresholdAD(_Detector1D):
     This detector compares time series values with user-given thresholds, and
     identifies time points as anomalous when values are beyond the thresholds.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     low: float, optional
@@ -144,14 +150,6 @@ class ThresholdAD(_Detector1D):
     high: float, optional
         Threshold above which a value is regarded anomaly. Default: None, i.e.
         no threshold on lower side.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -181,6 +179,13 @@ class QuantileAD(_Detector1D):
     of historical data, and identifies time points as anomalous when values
     are beyond the thresholds.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     low: float, optional
@@ -198,14 +203,6 @@ class QuantileAD(_Detector1D):
 
     abs_high_: float
         The fitted upper bound of normal range.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -243,6 +240,13 @@ class InterQuartileRangeAD(_Detector1D):
     historical data, and identifies time points as anomalous when differences
     are beyond the inter-quartile range times a user-given factor c.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     c: float, or 2-tuple (float, float), optional
@@ -257,14 +261,6 @@ class InterQuartileRangeAD(_Detector1D):
 
     abs_high_: float
         The fitted upper bound of normal range.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -322,6 +318,13 @@ class GeneralizedESDTestAD(_Detector1D):
     follow an approximately normal distribution. Please only use this detector
     when this assumption holds.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     [1] Rosner, Bernard (May 1983), Percentage Points for a Generalized ESD
     Many-Outlier Procedure,Technometrics, 25(2), pp. 165-172.
 
@@ -332,13 +335,6 @@ class GeneralizedESDTestAD(_Detector1D):
     alpha: float, optional
         Significance level. Default: 0.05.
 
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
     """
 
     _default_params = {"alpha": 0.05}
@@ -417,6 +413,13 @@ class PersistAD(_Detector1D):
     This detector is internally implemented as a `Pipenet` object. Advanced
     users may learn more details by checking attribute `pipe_`.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     window: int, optional
@@ -444,13 +447,6 @@ class PersistAD(_Detector1D):
     ----------
     pipe_: adtk.pipe.Pipenet
         Internal pipenet object.
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -582,6 +578,13 @@ class LevelShiftAD(_Detector1D):
     This detector is internally implemented as a `Pipenet` object. Advanced
     users may learn more details by checking attribute `pipe_`.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     window: int, optional
@@ -605,13 +608,6 @@ class LevelShiftAD(_Detector1D):
     ----------
     pipe_: adtk.pipe.Pipenet
         Internal pipenet object.
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -735,6 +731,13 @@ class VolatilityShiftAD(_Detector1D):
     This detector is internally implemented as a `Pipenet` object. Advanced
     users may learn more details by checking attribute `pipe_`.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     window: int, optional
@@ -762,14 +765,6 @@ class VolatilityShiftAD(_Detector1D):
     ----------
     pipe_: adtk.pipe.Pipenet
         Internal pipenet object.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -904,6 +899,13 @@ class AutoregressionAD(_Detector1D):
     This detector is internally implemented aattribute `pipe_`.nced
     users may learn more details by checking attribute `pipe_`.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     n_steps: int, optional
@@ -932,14 +934,6 @@ class AutoregressionAD(_Detector1D):
     ----------
     pipe_: adtk.pipe.Pipenet
         Internal pipenet object.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -1065,6 +1059,13 @@ class SeasonalAD(_Detector1D):
     This detector is internally implemented aattribute `pipe_`.nced
     users may learn more details by checking attribute `pipe_`.
 
+    This is an univariate detector. When it is applied to a multivariate time
+    series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     method: str, optional
@@ -1100,14 +1101,6 @@ class SeasonalAD(_Detector1D):
 
     pipe_: adtk.pipe.Pipenet
         Internal pipenet object.
-
-
-    This is an univariate detector. When it is applied to a multivariate time
-    series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 

--- a/src/adtk/transformer/transformer_1d.py
+++ b/src/adtk/transformer/transformer_1d.py
@@ -126,7 +126,6 @@ class StandardScale(_Transformer1D):
     """Transformer that scales time series such that mean is equal to 0 and
     standard deviation is equal to 1.
 
-
     This is an univariate transformer. When it is applied to a multivariate
     time series (i.e. pandas DataFrame), it will be applied to every series
     independently.
@@ -154,6 +153,13 @@ class StandardScale(_Transformer1D):
 class RollingAggregate(_Transformer1D):
     """Transformer that roll a sliding window along a time series, and
     aggregates using a user-selected operation.
+
+    This is an univariate transformer. When it is applied to a multivariate
+    time series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
 
     Parameters
     ----------
@@ -207,14 +213,6 @@ class RollingAggregate(_Transformer1D):
     min_periods: int, optional
         Minimum number of observations in window required to have a value.
         Default: None, i.e. all observations must have values.
-
-
-    This is an univariate transformer. When it is applied to a multivariate
-    time series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -395,6 +393,13 @@ class DoubleRollingAggregate(_Transformer1D):
     series, aggregates using a user-given operation, and calcuates the
     difference of aggregated metrics between two sliding windows.
 
+    This is an univariate transformer. When it is applied to a multivariate
+    time series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     agg: str, function, or tuple
@@ -475,14 +480,6 @@ class DoubleRollingAggregate(_Transformer1D):
         number measuring the difference.
 
         Default: 'l1'
-
-
-    This is an univariate transformer. When it is applied to a multivariate
-    time series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -862,6 +859,13 @@ class NaiveSeasonalDecomposition(_Deseasonal):
     residual series. It may not applicable for seasonal time series with strong
     trend besides seasonal effects, where STLDecomposition may be helpful.
 
+    This is an univariate transformer. When it is applied to a multivariate
+    time series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     freq: int, optional
@@ -876,14 +880,6 @@ class NaiveSeasonalDecomposition(_Deseasonal):
 
     seasonal_: pandas.Series
         Seasonal pattern extracted from training series.
-
-
-    This is an univariate transformer. When it is applied to a multivariate
-    time series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -913,6 +909,13 @@ class STLDecomposition(_Deseasonal):
     noise (residual). This transformer performs STL decomposition to a time
     series and returns residual series.
 
+    This is an univariate transformer. When it is applied to a multivariate
+    time series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     freq: int, optional
@@ -927,14 +930,6 @@ class STLDecomposition(_Deseasonal):
 
     seasonal_: pandas.Series
         Seasonal pattern extracted from training series.
-
-
-    This is an univariate transformer. When it is applied to a multivariate
-    time series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 
@@ -984,6 +979,13 @@ class Retrospect(_Transformer1D):
     u_[t-5], and a series y_t are needed to learn the relationship between
     control and outcome.
 
+    This is an univariate transformer. When it is applied to a multivariate
+    time series (i.e. pandas DataFrame), it will be applied to every series
+    independently. All parameters can be defined as a dict object where key-
+    value pairs are series names (i.e. column names of DataFrame) and the
+    model parameter for that series. If not, then the same parameter will be
+    applied to all series.
+
     Parameters
     ----------
     n_steps: int, optional
@@ -1023,14 +1025,6 @@ class Retrospect(_Transformer1D):
             2017-01-08	6.0	4.0	2.0
             2017-01-09	7.0	5.0	3.0
             2017-01-10	8.0	6.0	4.0
-
-
-    This is an univariate transformer. When it is applied to a multivariate
-    time series (i.e. pandas DataFrame), it will be applied to every series
-    independently. All parameters can be defined as a dict object where key-
-    value pairs are series names (i.e. column names of DataFrame) and the
-    model parameter for that series. If not, then the same parameter will be
-    applied to all series.
 
     """
 


### PR DESCRIPTION
We had a note regarding applying a univariate detector/transformer to DataFrame in the bottom of the docstrings of every univariate model. However, it seems sphinx had a problem formatting it correctly in pipe-derived models (probably because the attribute session right above it refers to an internal class with hyperlink). A quick fix is to move the note to append the description paragraph, which is also a more suitable place for it.

In this PR, we did so.