### PR TITLE
travis coveralls badge status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,9 @@ after_success:
     - py.test --cov adtk
     - coveralls
 
+branches:
+    only:
+    - master
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/arundo/adtk.svg?branch=master)](https://travis-ci.com/arundo/adtk)
 [![Docs](https://readthedocs.com/projects/arundo-adtk/badge/?version=stable)](https://arundo-adtk.readthedocs-hosted.com)
-[![Coverage Status](https://coveralls.io/repos/github/arundo/adtk/badge.svg?branch=coverage)](https://coveralls.io/github/arundo/adtk?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/github/arundo/adtk/badge.svg?branch=master)](https://coveralls.io/github/arundo/adtk?branch=master)
 [![PyPI](https://img.shields.io/pypi/v/adtk)](https://pypi.org/project/adtk/)
 [![Downloads](https://pepy.tech/badge/adtk)](https://pepy.tech/project/adtk)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
The status badges of travis building and coveralls is not updated as they are not ran over master branch. We fixed it here.