### PR TITLE
Allow AD to predict only based on past values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = adtk
-version = 0.6.2
+version = 0.6.1
 author = Arundo Analytics, Inc.
 maintainer = Tailai Wen
 maintainer_email = tailai.wen@arundo.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = adtk
-version = 0.6.0
+version = 0.6.1
 author = Arundo Analytics, Inc.
 maintainer = Tailai Wen
 maintainer_email = tailai.wen@arundo.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = adtk
-version = 0.6.1
+version = 0.6.2
 author = Arundo Analytics, Inc.
 maintainer = Tailai Wen
 maintainer_email = tailai.wen@arundo.com

--- a/src/adtk/detector/_detector_1d.py
+++ b/src/adtk/detector/_detector_1d.py
@@ -488,11 +488,12 @@ class PersistAD(_TrainableUnivariateDetector):
         self.window = window
         self.min_periods = min_periods
         self.agg = agg
+        self.center = center
         self._sync_params()
 
     @property
     def _param_names(self) -> Tuple[str, ...]:
-        return ("window", "c", "side", "min_periods", "agg")
+        return ("window", "c", "side", "min_periods", "agg", "center")
 
     def _sync_params(self) -> None:
         if self.agg not in ["median", "mean"]:
@@ -507,12 +508,14 @@ class PersistAD(_TrainableUnivariateDetector):
             agg=self.agg,
             window=(self.window, 1),
             min_periods=(self.min_periods, 1),
+            center=self.center,
         )
         self.pipe_.steps["iqr_ad"]["model"].set_params(c=(None, self.c))
         self.pipe_.steps["diff"]["model"].set_params(
             agg=self.agg,
             window=(self.window, 1),
             min_periods=(self.min_periods, 1),
+            center=self.center,
         )
         self.pipe_.steps["sign_check"]["model"].set_params(
             high=(
@@ -660,11 +663,12 @@ class LevelShiftAD(_TrainableUnivariateDetector):
         self.side = side
         self.window = window
         self.min_periods = min_periods
+        self.center = center
         self._sync_params()
 
     @property
     def _param_names(self) -> Tuple[str, ...]:
-        return ("window", "c", "side", "min_periods")
+        return ("window", "c", "side", "min_periods", "center")
 
     def _sync_params(self) -> None:
         if self.side not in ["both", "positive", "negative"]:
@@ -672,11 +676,11 @@ class LevelShiftAD(_TrainableUnivariateDetector):
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
         self.pipe_.steps["diff_abs"]["model"].set_params(
-            window=self.window, min_periods=self.min_periods
+            window=self.window, min_periods=self.min_periods, center=center
         )
         self.pipe_.steps["iqr_ad"]["model"].set_params(c=(None, self.c))
         self.pipe_.steps["diff"]["model"].set_params(
-            window=self.window, min_periods=self.min_periods
+            window=self.window, min_periods=self.min_periods, center=center
         )
         self.pipe_.steps["sign_check"]["model"].set_params(
             high=(

--- a/src/adtk/detector/_detector_1d.py
+++ b/src/adtk/detector/_detector_1d.py
@@ -676,11 +676,11 @@ class LevelShiftAD(_TrainableUnivariateDetector):
                 "Parameter `side` must be 'both', 'positive' or 'negative'."
             )
         self.pipe_.steps["diff_abs"]["model"].set_params(
-            window=self.window, min_periods=self.min_periods, center=center
+            window=self.window, min_periods=self.min_periods, center=self.center
         )
         self.pipe_.steps["iqr_ad"]["model"].set_params(c=(None, self.c))
         self.pipe_.steps["diff"]["model"].set_params(
-            window=self.window, min_periods=self.min_periods, center=center
+            window=self.window, min_periods=self.min_periods, center=self.center
         )
         self.pipe_.steps["sign_check"]["model"].set_params(
             high=(
@@ -1149,15 +1149,16 @@ class SeasonalAD(_TrainableUnivariateDetector):
         self.side = side
         self.c = c
         self.trend = trend
+        self.two_sided = two_sided
         self._sync_params()
 
     @property
     def _param_names(self) -> Tuple[str, ...]:
-        return ("freq", "side", "c", "trend")
+        return ("freq", "side", "c", "trend", "two_sided")
 
     def _sync_params(self) -> None:
         self.pipe_.steps["deseasonal_residual"]["model"].set_params(
-            freq=self.freq, trend=self.trend
+            freq=self.freq, trend=self.trend, two_sided=self.two_sided
         )
         self.pipe_.steps["iqr_ad"]["model"].set_params(c=(None, self.c))
         self.pipe_.steps["sign_check"]["model"].set_params(

--- a/src/adtk/detector/_detector_1d.py
+++ b/src/adtk/detector/_detector_1d.py
@@ -406,6 +406,11 @@ class PersistAD(_TrainableUnivariateDetector):
         Aggregation operation of the time window, either "mean" or "median".
         Default: "median".
 
+    center: bool, optional
+        If True, the current point is the right edge of right window;
+        Otherwise, it is the right edge of left window.
+        Default: True.
+
     Attributes
     ----------
     pipe_: adtk.pipe.Pipenet
@@ -420,6 +425,7 @@ class PersistAD(_TrainableUnivariateDetector):
         side: str = "both",
         min_periods: Optional[int] = None,
         agg: str = "median",
+        center=True
     ) -> None:
         self.pipe_ = Pipenet(
             {
@@ -427,7 +433,7 @@ class PersistAD(_TrainableUnivariateDetector):
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=(window, 1),
-                        center=True,
+                        center=center,
                         min_periods=(min_periods, 1),
                         diff="l1",
                     ),
@@ -441,7 +447,7 @@ class PersistAD(_TrainableUnivariateDetector):
                     "model": DoubleRollingAggregate(
                         agg=agg,
                         window=(window, 1),
-                        center=True,
+                        center=center,
                         min_periods=(min_periods, 1),
                         diff="diff",
                     ),
@@ -570,6 +576,11 @@ class LevelShiftAD(_TrainableUnivariateDetector):
         for that window. If 2-tuple, it defines the left and right window
         respectively. Default: None, i.e. all observations must have values.
 
+    center: bool, optional
+        If True, the current point is the right edge of right window;
+        Otherwise, it is the right edge of left window.
+        Default: True.
+
     Attributes
     ----------
     pipe_: adtk.pipe.Pipenet
@@ -587,6 +598,7 @@ class LevelShiftAD(_TrainableUnivariateDetector):
         min_periods: Union[
             Optional[int], Tuple[Optional[int], Optional[int]]
         ] = None,
+        center: bool = True
     ) -> None:
         self.pipe_ = Pipenet(
             {
@@ -594,7 +606,7 @@ class LevelShiftAD(_TrainableUnivariateDetector):
                     "model": DoubleRollingAggregate(
                         agg="median",
                         window=window,
-                        center=True,
+                        center=center,
                         min_periods=min_periods,
                         diff="l1",
                     ),
@@ -608,7 +620,7 @@ class LevelShiftAD(_TrainableUnivariateDetector):
                     "model": DoubleRollingAggregate(
                         agg="median",
                         window=window,
-                        center=True,
+                        center=center,
                         min_periods=min_periods,
                         diff="diff",
                     ),
@@ -1051,6 +1063,11 @@ class SeasonalAD(_TrainableUnivariateDetector):
     trend: bool, optional
         Whether to extract trend during decomposition. Default: False.
 
+    two_sided: bool, optional
+        The moving average method used in filtering out trend.
+        If True (default), a centered moving average is computed using the filt.
+        If False, the filter coefficients are for past values only.
+
     Attributes
     ----------
     freq_: int
@@ -1072,12 +1089,17 @@ class SeasonalAD(_TrainableUnivariateDetector):
         side: str = "both",
         c: float = 3.0,
         trend: bool = False,
+        two_sided: bool = True
     ) -> None:
         self.pipe_ = Pipenet(
             {
                 "deseasonal_residual": {
                     "model": (
-                        ClassicSeasonalDecomposition(freq=freq, trend=trend)
+                        ClassicSeasonalDecomposition(
+                            freq=freq,
+                            trend=trend,
+                            two_sided=two_sided
+                        )
                     ),
                     "input": "original",
                 },

--- a/src/adtk/detector/_detector_1d.py
+++ b/src/adtk/detector/_detector_1d.py
@@ -1065,7 +1065,7 @@ class SeasonalAD(_TrainableUnivariateDetector):
 
     two_sided: bool, optional
         The moving average method used in filtering out trend.
-        If True (default), a centered moving average is computed using the filt.
+        If True (default), a centered moving average is computed.
         If False, the filter coefficients are for past values only.
 
     Attributes

--- a/src/adtk/transformer/_transformer_1d.py
+++ b/src/adtk/transformer/_transformer_1d.py
@@ -729,7 +729,7 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
             seasonal_decompose_results = (
                 seasonal_decompose(s, period=self.freq_, two_sided=self.two_sided)
                 if parse(statsmodels.__version__) >= parse("0.11")
-                else seasonal_decompose(s, freq=self.freq_)
+                else seasonal_decompose(s, freq=self.freq_, two_sided=self.two_sided)
             )
             self.seasonal_ = getattr(seasonal_decompose_results, "seasonal")[
                 : self.freq_

--- a/src/adtk/transformer/_transformer_1d.py
+++ b/src/adtk/transformer/_transformer_1d.py
@@ -657,6 +657,11 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
         If False, the time series will be assumed the sum of seasonal pattern
         and residual. Default: False.
 
+    two_sided: bool, optional
+        The moving average method used in filtering out trend.
+        If True (default), a centered moving average is computed using the filt.
+        If False, the filter coefficients are for past values only.
+
     Attributes
     ----------
     freq_: int
@@ -669,11 +674,15 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
     """
 
     def __init__(
-        self, freq: Optional[int] = None, trend: bool = False
+        self,
+        freq: Optional[int] = None,
+        trend: bool = False,
+        two_sided: bool = True
     ) -> None:
         super().__init__()
         self.freq = freq
         self.trend = trend
+        self.two_sided = two_sided
 
     @property
     def _param_names(self) -> Tuple[str, ...]:
@@ -718,7 +727,7 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
         # get seasonal pattern
         if self.trend:
             seasonal_decompose_results = (
-                seasonal_decompose(s, period=self.freq_)
+                seasonal_decompose(s, period=self.freq_, two_sided=self.two_sided)
                 if parse(statsmodels.__version__) >= parse("0.11")
                 else seasonal_decompose(s, freq=self.freq_)
             )

--- a/src/adtk/transformer/_transformer_1d.py
+++ b/src/adtk/transformer/_transformer_1d.py
@@ -686,7 +686,7 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
 
     @property
     def _param_names(self) -> Tuple[str, ...]:
-        return ("freq", "trend")
+        return ("freq", "trend", "two_sided")
 
     def _fit_core(self, s: pd.Series) -> None:
         if not (

--- a/src/adtk/transformer/_transformer_1d.py
+++ b/src/adtk/transformer/_transformer_1d.py
@@ -659,7 +659,7 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
 
     two_sided: bool, optional
         The moving average method used in filtering out trend.
-        If True (default), a centered moving average is computed using the filt.
+        If True (default), a centered moving average is computed.
         If False, the filter coefficients are for past values only.
 
     Attributes
@@ -810,9 +810,9 @@ class ClassicSeasonalDecomposition(_TrainableUnivariateTransformer):
         # remove trend
         if self.trend:
             seasonal_decompose_results = (
-                seasonal_decompose(s, period=self.freq_)
+                seasonal_decompose(s, period=self.freq_, two_sided=self.two_sided)
                 if parse(statsmodels.__version__) >= parse("0.11")
-                else seasonal_decompose(s, freq=self.freq_)
+                else seasonal_decompose(s, freq=self.freq_, two_sided=self.two_sided)
             )
             s_trend = getattr(seasonal_decompose_results, "trend")
             s_detrended = s - s_trend


### PR DESCRIPTION
Allow SeasonalAD, LevelShiftAD and PersistAD to predict only based on past values
