### PR TITLE
removed internal styling in plot

### DIFF
--- a/src/adtk/visualization/_visualization.py
+++ b/src/adtk/visualization/_visualization.py
@@ -197,8 +197,6 @@ def plot(
         Axes where the plot(s) is drawn.
 
     """
-    # setup style
-    plt.style.use("seaborn-whitegrid")
 
     # initialize color generator
     color_generator = ColorGenerator()


### PR DESCRIPTION
The `seaborn-whitegrid` style is causing problem when plotting. It's better to remove this styling entirely so the user can set this by themselves. It will also avoid similar problems in future.